### PR TITLE
Fix Theme type by filling in empty properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
       # Publish
       - name: Upload binaries to release
+        if: github.ref == 'refs/heads/main'
         uses: svenstaro/upload-release-action@v2
         with:
           file: build/github_action_release.rbxm

--- a/src/App.luau
+++ b/src/App.luau
@@ -930,8 +930,8 @@ function App.tryConnect(self: App, connection: Types.DataStoreConnection)
 	end
 
 	if Settings.get("allScopes") and not connection.isOrdered then
-		connection.allScopes = true
-		connection.scope = "" -- Has to be to work
+		(connection::any).allScopes = true
+		(connection::any).scope = "" -- Has to be to work
 	end
 
 	local success, err = self.session:tryConnect(connection)

--- a/src/App.luau
+++ b/src/App.luau
@@ -930,8 +930,8 @@ function App.tryConnect(self: App, connection: Types.DataStoreConnection)
 	end
 
 	if Settings.get("allScopes") and not connection.isOrdered then
-		(connection::any).allScopes = true
-		(connection::any).scope = "" -- Has to be to work
+		(connection :: any).allScopes = true
+		(connection :: any).scope = "" -- Has to be to work
 	end
 
 	local success, err = self.session:tryConnect(connection)

--- a/src/App.luau
+++ b/src/App.luau
@@ -930,7 +930,7 @@ function App.tryConnect(self: App, connection: Types.DataStoreConnection)
 	end
 
 	if Settings.get("allScopes") and not connection.isOrdered then
-		(connection :: any).allScopes = true
+		(connection :: any).allScopes = true;
 		(connection :: any).scope = "" -- Has to be to work
 	end
 

--- a/src/UI/Theme.luau
+++ b/src/UI/Theme.luau
@@ -22,6 +22,23 @@ Theme.accentHues = {
 	neutral = 0, -- Special case
 }
 
+local defaultIcons = {
+	export = "rbxassetid://18872446140",
+	import = "rbxassetid://18872442909",
+	lookup = "rbxassetid://18872448764",
+	edit = "rbxassetid://18872450875",
+	delete = "rbxassetid://18872454033",
+	storage = "rbxassetid://18872458094",
+	insert = "rbxassetid://18872509789",
+	pin = "rbxassetid://18886260860",
+	unpin = "rbxassetid://18886277155",
+	rename = "rbxassetid://18901732408",
+	maximize = "rbxassetid://18962414864",
+	minimize = "rbxassetid://18962422050",
+	fill = "rbxassetid://84916176036418",
+	select = "rbxassetid://127081818194911",
+}
+
 -- Reference: https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color
 function Theme.srgbToLinear(colorChannel: number)
 	if colorChannel <= 0.03928 then
@@ -71,22 +88,7 @@ function Theme.new(): Theme
 		preset = "dark",
 	}, Theme) :: Theme
 	self.colors = Theme.generatePreset(self.preset, self.accent)
-	self.icons = {
-		export = "rbxassetid://18872446140",
-		import = "rbxassetid://18872442909",
-		lookup = "rbxassetid://18872448764",
-		edit = "rbxassetid://18872450875",
-		delete = "rbxassetid://18872454033",
-		storage = "rbxassetid://18872458094",
-		insert = "rbxassetid://18872509789",
-		pin = "rbxassetid://18886260860",
-		unpin = "rbxassetid://18886277155",
-		rename = "rbxassetid://18901732408",
-		maximize = "rbxassetid://18962414864",
-		minimize = "rbxassetid://18962422050",
-		fill = "rbxassetid://84916176036418",
-		select = "rbxassetid://127081818194911",
-	}
+	self.icons = table.clone(defaultIcons)
 
 	self._colorsChanged = Instance.new("BindableEvent")
 	self.colorsChanged = self._colorsChanged.Event
@@ -803,5 +805,13 @@ StudioSettings.ThemeChanged:Connect(function()
 	end
 end)
 
-export type Theme = typeof(setmetatable({}, Theme))
+export type Theme = typeof(setmetatable({
+	accent = "red",
+	preset = "dark",
+	colors = Theme.generatePreset("\red","dark"),
+	icons = defaultIcons,
+	_colorsChanged = Instance.new("BindableEvent"),
+	colorsChanged = Instance.new("BindableEvent").Event,
+}, Theme))
+
 return Theme

--- a/src/UI/Theme.luau
+++ b/src/UI/Theme.luau
@@ -808,7 +808,7 @@ end)
 export type Theme = typeof(setmetatable({
 	accent = "red",
 	preset = "dark",
-	colors = Theme.generatePreset("\red","dark"),
+	colors = Theme.generatePreset("red", "dark"),
 	icons = defaultIcons,
 	_colorsChanged = Instance.new("BindableEvent"),
 	colorsChanged = Instance.new("BindableEvent").Event,

--- a/src/UI/init.luau
+++ b/src/UI/init.luau
@@ -669,7 +669,7 @@ function UI:createDataUsageCard(keyUsage: number, metadataUsage: number)
 end
 
 function UI:promptDuplicateMoveKey(position: Vector2, isAllScopes: boolean): { key: string, shouldDelete: boolean }?
-	local popup, modal = PopupFormStyleState.createPopup(self.theme, self.gui.Parent, UDim2.fromOffset(0, 0), {
+	local popup, modal = PopupFormStyleState.createPopup(self.theme, self.gui.Parent, Vector2.zero, {
 		title = "Duplicate/Move Key",
 		buttons = { { text = "Duplicate", options = { style = "primary" } }, { text = "Cancel" } },
 		addContents = function(parent)


### PR DESCRIPTION
Currently, the `Theme` type has optional properties (e.g. `string?`) as the type template established by `typeof({},setmetatable(Theme))` is missing the properties established in `Theme.new`. This commit fixes this issue by adding default/placeholder values to the type definition.